### PR TITLE
Match requests against regexps and arrays

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yandex-dialogs-sdk",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Build your skill for Alice with ease.",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
     "Alice",
     "yandex-dialogs",
     "alice",
+    "alisa",
     "skills",
     "alice-sdk",
     "alice-dialogs",
-    "yandex-dialogs-sdk"
+    "yandex-dialogs-sdk",
+    "imperator"
   ],
   "author": "Phil Romanov (@fletcherist)",
   "license": "MIT",
@@ -29,7 +31,10 @@
     "body-parser": "^1.18.2",
     "express": "^4.16.3",
     "fuzzysearch": "^1.0.3",
-    "node-fetch": "^2.1.1"
+    "global": "^4.3.2",
+    "jest": "^22.4.3",
+    "node-fetch": "^2.1.1",
+    "npm": "^5.8.0"
   },
   "devDependencies": {
     "eslint": "^4.19.0"

--- a/src/alice.js
+++ b/src/alice.js
@@ -19,8 +19,22 @@ class Alice {
   }
 
   command(name, callback) {
+    let type
+
+    if (typeof name === 'string') {
+      type = 'string'
+      name = name.toLowerCase()
+    } else if (name instanceof RegExp) {
+      type = 'regexp'
+    } else if (Array.isArray(name)) {
+      type = 'array'
+    } else {
+      throw new Error('Unexpecto patronus')
+    }
+
     this.commands.push({
-      name: name.toLowerCase(),
+      name: name,
+      type: type,
       callback: callback
     })
   }
@@ -37,7 +51,6 @@ class Alice {
   async handleRequestBody(req) {
     const requestedCommandName = selectCommand(req)
 
-    /* @TODO: implement fuzzy-search */
     const requestedCommands = this.commands.filter(command =>
       command.name === requestedCommandName)
 

--- a/src/tests/alice.spec.js
+++ b/src/tests/alice.spec.js
@@ -1,0 +1,29 @@
+const Alice = require('../alice')
+
+const generateRequest = (commandText, utteranceText) => ({
+  'meta': {
+    'client_id': 'Developer Console',
+    'locale': 'ru-RU',
+    'timezone': 'UTC'
+  },
+  'request': {
+    'command': commandText,
+    'original_utterance': utteranceText || commandText,
+    'type': 'SimpleUtterance'
+  },
+  'session': {
+    'message_id': 0,
+    'new': true
+  },
+  'version': '1.0'
+})
+
+test('common test for alice', async(done) => {
+  const alice = new Alice()
+  
+  // register commands to match the request to
+  alice.command('привки', ctx => done())
+
+  // test matches
+  alice.handleRequestBody(generateRequest('Привет, как дела?'))
+})

--- a/src/tests/alice.spec.js
+++ b/src/tests/alice.spec.js
@@ -18,12 +18,33 @@ const generateRequest = (commandText, utteranceText) => ({
   'version': '1.0'
 })
 
-test('common test for alice', async(done) => {
+// Test for matching all command types
+
+test('matching with string', async(done) => {
+  const alice = new Alice()
+
+  alice.command('привки', ctx => done())
+  alice.handleRequestBody(generateRequest('Привет, как дела?'))
+})
+
+test('matching with array', async(done) => {
   const alice = new Alice()
   
-  // register commands to match the request to
-  alice.command('привки', ctx => done())
-
-  // test matches
+  alice.command(['привки', 'как'], ctx => done())
   alice.handleRequestBody(generateRequest('Привет, как дела?'))
+})
+
+test('matching with regexp', async(done) => {
+  const alice = new Alice()
+  
+  alice.command(/[а-яё]+/i, ctx => done())
+  alice.handleRequestBody(generateRequest('Привет как дела'))
+})
+
+test('priority check, strings over regexps', async(done) => {
+  const alice = new Alice()
+  
+  alice.command(/[а-яё]+/i, ctx => new Error('cyka'))
+  alice.command('привет', ctx => done())
+  alice.handleRequestBody(generateRequest('Привет как дела'))
 })


### PR DESCRIPTION
#2 `alice.command` now accepts regexps and arrays, not only strings, as an argument for name. 