### PR TITLE
fix: more strict fuse options

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -9,8 +9,8 @@ class Commands {
   constructor(config = {}) {
     this.commands = []
     this.fuseOptions = {
-      tokenize: true,
-      treshold: config.fuzzyTreshold || 0.1,
+      tokenize: false,
+      threshold: config.fuzzyTreshold || 0.3,
       distance: config.fuzzyDistance || 10,
       keys: ['name']
     }


### PR DESCRIPTION
`tokenize` разбивает строку на слова и ищет совпадение хотя бы по одному из них.
Это поведение неожиданно и непредсказуемо.

В `threshold` была пропущена буква (поэтому бралось умолчание 0.6), но 0.1 слишком мало, я пару раз уже подбирал для fuse этот параметр, оптимальным по четкости мне показался 0.3, он практически не прощает ошибок, зато не дает ложных срабатываний.