### PR TITLE
fix: searchRegexps always returns true

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -36,7 +36,7 @@ class Commands {
   _searchRegexps(requestedCommandName) {
     const regexpCommands = this._regexps
     // @TODO: include matches and captured groups
-    return regexpCommands.filter(reg => requestedCommandName.match(reg))
+    return regexpCommands.filter(reg => requestedCommandName.match(reg.name))
   }
 
   search(requestedCommandName) {


### PR DESCRIPTION
Вместо текста в команде как регулярка использовался сам объект команды, это почему-то не давало ошибку, зато давало всегда true при проверке.