### PR TITLE
fix: TYPE_FIGURE excluded from Commands._strings()

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -35,7 +35,7 @@ export default class Commands implements CommandsInterface {
   }
   get _strings() {
     return this.commands.filter((command) =>
-      [TYPE_FIGURE, TYPE_STRING, TYPE_ARRAY].includes(command.type),
+      [TYPE_STRING, TYPE_ARRAY].includes(command.type),
     )
   }
   get _figures() {


### PR DESCRIPTION
В связи с #42 я решил временно избавиться от fuse.js, сделать всё на трех оставшихся типах.
Без этого коммита в strings попадают фигуры.

Ну и вообще, фигурам не место в строках, они не должны находиться через fuse.js