### PR TITLE
Добавляет копирование папки types в dist при сборке

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint src",
     "test": "jest",
     "dev": "tsc -w --declaration",
-    "build": "rm -rf dist && tsc --declaration",
+    "build": "rm -rf dist && tsc --declaration; cp -r ./src/types ./dist/types",
     "version": "npm run changelog && git add CHANGELOG.md",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 0",
     "release": "conventional-github-releaser -p angular",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     "fuse.js": "^3.2.0",
     "loglevel": "^1.6.1",
     "loglevel-plugin-prefix": "^0.8.4",
-    "node-fetch": "^2.1.2",
-    "ramda": "^0.25.0"
+    "node-fetch": "^2.1.2"
   },
   "devDependencies": {
     "@types/express": "^4.16.0",

--- a/src/alice.ts
+++ b/src/alice.ts
@@ -24,7 +24,7 @@ import aliceStateMiddleware from './middlewares/aliceStateMiddleware'
 import { IConfig } from './types/alice'
 import { ICommand } from './types/command'
 import { IContext } from './types/context'
-import { WebhookResponse, WebhookRequest } from 'webhook'
+import { WebhookResponse, WebhookRequest } from './types/webhook'
 import { EventInterface, EventEmitterInterface } from './types/eventEmitter'
 import eventEmitter from './eventEmitter'
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -11,7 +11,7 @@ import {
 } from './constants'
 import { ICommands } from './types/commands'
 import { ICommand } from './types/command'
-import { IContext } from 'context'
+import { IContext } from './types/context'
 
 export default class Commands implements ICommands {
   public commands: ICommand[]

--- a/src/eventEmitter.ts
+++ b/src/eventEmitter.ts
@@ -1,4 +1,3 @@
-import { merge } from 'ramda'
 import {
   EventEmitterInterface,
   EventType,

--- a/src/middlewares.ts
+++ b/src/middlewares.ts
@@ -1,4 +1,3 @@
-import { merge } from 'ramda'
 import Context from './context'
 
 export type MiddlewareType = (ctx: Context) => Context

--- a/src/scene.ts
+++ b/src/scene.ts
@@ -5,7 +5,7 @@ import Context from './context'
 
 import { IConfig } from './types/alice'
 import { WebhookRequest, WebhookResponse } from './types/webhook'
-import { IContext } from 'context'
+import { IContext } from './types/context'
 
 const selectCommand = (req) => req.request.command
 

--- a/src/session.ts
+++ b/src/session.ts
@@ -1,5 +1,3 @@
-import { merge } from 'ramda'
-
 export default class Session {
     public sessionId: string
     public data: {}
@@ -32,6 +30,6 @@ export default class Session {
     }
 
     public update(data) {
-        this.data = merge(this.data, data)
+        this.data = Object.assign(this.data, data)
     }
 }

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -1,4 +1,3 @@
-import { merge } from 'ramda'
 import Session from './session'
 
 class Sessions {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,10 +9,7 @@
         "outDir": "dist",
         "baseUrl": ".",
         "paths": {
-            "*": [
-                "node_modules/*",
-                "src/types/*"
-            ]
+            "*": ["node_modules/*"]
         },
         "types": ["node", "jest", "express"],
         // typeRoots option has been previously configured


### PR DESCRIPTION
В будущем может стоит вообще не использовать такую папку с типами - классы сами описывают свой тип. Но пока, чтобы ts не ругался при сборке npm пакета #47, можно скопировать.