### PR TITLE
feat: implement pure http server on listen method

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "homepage": "https://github.com/fletcherist/yandex-dialogs-sdk#readme",
   "dependencies": {
     "@types/node-fetch": "^2.1.2",
+    "debug": "^3.1.0",
     "node-fetch": "^2.1.2"
   },
   "devDependencies": {
@@ -63,7 +64,7 @@
     "prettier": "^1.13.7",
     "ts-jest": "^23.0.0",
     "tslint": "^5.10.0",
-    "typescript": "^2.9.2",
+    "typescript": "^3.0.1",
     "typescript-eslint-parser": "^16.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
   },
   "homepage": "https://github.com/fletcherist/yandex-dialogs-sdk#readme",
   "dependencies": {
-    "node-fetch": "^2.1.2"
+    "node-fetch": "^2.1.2",
+    "@types/node-fetch": "^2.1.2"
   },
   "devDependencies": {
     "@types/debug": "^0.0.30",
-    "@types/node-fetch": "^2.1.2",
     "@types/jest": "^23.1.3",
     "@types/node": "^10.5.1",
     "conventional-changelog-cli": "^2.0.0",
@@ -64,7 +64,7 @@
     "prettier": "^1.13.7",
     "ts-jest": "^23.0.0",
     "tslint": "^5.10.0",
-    "typescript": "^3.0.1",
+    "typescript": "^2.9.2",
     "typescript-eslint-parser": "^16.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,17 +49,17 @@
   },
   "homepage": "https://github.com/fletcherist/yandex-dialogs-sdk#readme",
   "dependencies": {
-    "@types/node-fetch": "^2.1.2",
-    "debug": "^3.1.0",
     "node-fetch": "^2.1.2"
   },
   "devDependencies": {
-    "@types/express": "^4.16.0",
+    "@types/debug": "^0.0.30",
+    "@types/node-fetch": "^2.1.2",
     "@types/jest": "^23.1.3",
     "@types/node": "^10.5.1",
     "conventional-changelog-cli": "^2.0.0",
     "conventional-github-releaser": "^3.1.0",
     "husky": "^0.14.3",
+    "debug": "^3.1.0",
     "jest": "^23.2.0",
     "prettier": "^1.13.7",
     "ts-jest": "^23.0.0",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   },
   "homepage": "https://github.com/fletcherist/yandex-dialogs-sdk#readme",
   "dependencies": {
-    "node-fetch": "^2.1.2",
-    "@types/node-fetch": "^2.1.2"
+    "@types/node-fetch": "^2.1.2",
+    "node-fetch": "^2.1.2"
   },
   "devDependencies": {
     "@types/debug": "^0.0.30",
@@ -58,8 +58,8 @@
     "@types/node": "^10.5.1",
     "conventional-changelog-cli": "^2.0.0",
     "conventional-github-releaser": "^3.1.0",
-    "husky": "^0.14.3",
     "debug": "^3.1.0",
+    "husky": "^0.14.3",
     "jest": "^23.2.0",
     "prettier": "^1.13.7",
     "ts-jest": "^23.0.0",

--- a/src/alice.ts
+++ b/src/alice.ts
@@ -6,10 +6,7 @@ import { IContext } from './context';
 import { IApiResponse } from './api/response';
 import { ALICE_PROTOCOL_VERSION } from './constants';
 
-export interface IAliceConfig extends IImagesApiConfig {
-  oAuthToken?: string;
-  skillId?: string;
-}
+export interface IAliceConfig extends IImagesApiConfig {}
 
 export interface IAlice {
   readonly imagesApi: IImagesApi;

--- a/src/alice.ts
+++ b/src/alice.ts
@@ -1,3 +1,4 @@
+import * as http from 'http';
 import { IImagesApiConfig, IImagesApi, ImagesApi } from './imagesApi';
 import { Middleware, IMiddlewareResult } from './middleware/middleware';
 import { IApiRequest } from './api/request';
@@ -18,11 +19,13 @@ export class Alice implements IAlice {
   private readonly _config: IAliceConfig;
   private readonly _middlewares: Middleware[];
   private readonly _imagesApi: IImagesApi;
+  private _server: object | null;
 
   constructor(config: IAliceConfig) {
     this._config = config;
     this._middlewares = [];
     this._imagesApi = new ImagesApi(this._config);
+    this._server = null;
   }
 
   private _buildContext(request: IApiRequest): IContext {
@@ -35,7 +38,7 @@ export class Alice implements IAlice {
     context: IContext,
   ): Promise<IMiddlewareResult | null> {
     const middlewares = Array.from(this._middlewares);
-    if (middlewares.length <= 0) {
+    if (middlewares.length === 0) {
       return null;
     }
 
@@ -43,8 +46,7 @@ export class Alice implements IAlice {
     const next = async (
       context: IContext,
     ): Promise<IMiddlewareResult | null> => {
-      const middleware = middlewares[index];
-      index--;
+      const middleware = middlewares[index--];
       return middleware(context, index <= 0 ? null : next);
     };
     return next(context);
@@ -79,6 +81,46 @@ export class Alice implements IAlice {
       },
       version: ALICE_PROTOCOL_VERSION,
     };
+  }
+
+  public listen(
+    port: number = 80,
+    webhookUrl: string = '/',
+    callback?: () => void,
+  ) {
+    this._server = http
+      .createServer(
+        async (request: http.ServerRequest, response: http.ServerResponse) => {
+          const body: (string | Buffer)[] = [];
+          request
+            .on('data', chunk => {
+              body.push(chunk);
+            })
+            .on('end', async () => {
+              const requestData = Buffer.from(body).toString();
+              if (request.method === 'POST' && request.url === webhookUrl) {
+                try {
+                  const requestBody = JSON.parse(requestData);
+                  const responseBody = await this.handleRequest(requestBody);
+                  response.statusCode = 200;
+                  response.setHeader('Content-Type', 'application/json');
+                  response.end(JSON.stringify(responseBody));
+                } catch (error) {
+                  throw new Error(error);
+                }
+              } else {
+                response.statusCode = 400;
+                return response.end();
+              }
+            });
+        },
+      )
+      .listen(port, () => {
+        if (typeof callback === 'function') {
+          return callback();
+        }
+      });
+    return this._server;
   }
 
   public use(middleware: Middleware): void {

--- a/src/alice.ts
+++ b/src/alice.ts
@@ -1,14 +1,10 @@
-import * as http from 'http';
-import _debug from 'debug';
 import { IImagesApiConfig, IImagesApi, ImagesApi } from './imagesApi';
 import { WebhookServer, IWebhookServer } from './server/webhookServer';
 import { Middleware, IMiddlewareResult } from './middleware/middleware';
 import { IApiRequest } from './api/request';
 import { IContext } from './context';
 import { IApiResponse } from './api/response';
-import { ALICE_PROTOCOL_VERSION, LIBRARY_NAME } from './constants';
-
-const debug = _debug(LIBRARY_NAME);
+import { ALICE_PROTOCOL_VERSION } from './constants';
 
 export interface IAliceConfig extends IImagesApiConfig {
   oAuthToken?: string;

--- a/src/api/response.ts
+++ b/src/api/response.ts
@@ -1,7 +1,7 @@
 export interface IApiResponseCardButton {
   text: string;
   url?: string;
-  payload?: Object;
+  payload?: object;
 }
 
 export interface IApiResponseCardFooter {
@@ -49,7 +49,7 @@ export type IApiResponseCard =
 export interface IApiResponseBodyButton {
   title: string;
   url?: string;
-  payload?: Object;
+  payload?: object;
   hide?: boolean;
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,2 +1,3 @@
 export const ALICE_PROTOCOL_VERSION = '1.0';
 export const ALICE_API_URL = 'https://dialogs.yandex.net/api/v1/skills';
+export const LIBRARY_NAME = 'yandex-dialogs-sdk';

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,3 @@
+import _debug from 'debug';
+import { LIBRARY_NAME } from './constants';
+export default _debug(LIBRARY_NAME);

--- a/src/imagesApi.ts
+++ b/src/imagesApi.ts
@@ -7,14 +7,14 @@ import {
 } from './api/image';
 
 export interface IImagesApiConfig {
-  oAuthToken: string;
-  skillId: string;
+  oAuthToken?: string;
+  skillId?: string;
 }
 
 interface IImagesApiRequestParams {
   path: string;
   method?: 'GET' | 'POST';
-  body?: Object;
+  body?: object;
 }
 
 export interface IImagesApi {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,16 +9,6 @@ export {
   CommandMatcher,
 } from './command/command';
 
-import { Alice } from './alice';
-/**
- * For compatibility with commonjs
- * @example const Alice = require('yandex-dialogs-sdk')
- */
-module.exports = Alice;
-exports = module.exports;
-
-export default Alice;
-
 export { Reply } from './reply/reply';
 
 export { InMemorySession } from './session/inMemorySession';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,16 @@ export {
   CommandMatcher,
 } from './command/command';
 
+import { Alice } from './alice';
+/**
+ * For compatibility with commonjs
+ * @example const Alice = require('yandex-dialogs-sdk')
+ */
+module.exports = Alice;
+exports = module.exports;
+
+export default Alice;
+
 export { Reply } from './reply/reply';
 
 export { InMemorySession } from './session/inMemorySession';

--- a/src/middleware/middleware.ts
+++ b/src/middleware/middleware.ts
@@ -15,4 +15,4 @@ export type Middleware<
 > = (
   context: TContextFrom,
   next: MiddlewareNext<TContextTo> | null,
-) => IMiddlewareResult | null | Promise<IMiddlewareResult | null>;
+) => IMiddlewareResult | Promise<IMiddlewareResult | null>;

--- a/src/server/webhookServer.ts
+++ b/src/server/webhookServer.ts
@@ -1,0 +1,74 @@
+import * as http from 'http';
+import _debug from 'debug';
+import { LIBRARY_NAME } from '../constants';
+import { IAlice } from '../alice';
+
+const debug = _debug(LIBRARY_NAME);
+
+export interface IWebhookServerConfig {
+  port: number;
+  webhookUrl: string;
+  options: object;
+  handleRequest: IAlice['handleRequest'];
+}
+export interface IWebhookServer {
+  start(): void;
+  stop(): void;
+}
+
+export class WebhookServer {
+  private server: http.Server;
+  private port: number;
+  private webhookUrl: string;
+  private isServerStarted: boolean;
+  private handleRequest: IAlice['handleRequest'];
+
+  constructor(config: IWebhookServerConfig) {
+    this.port = config.port;
+    this.webhookUrl = config.webhookUrl;
+    this.handleRequest = config.handleRequest;
+    this.isServerStarted = false;
+
+    debug(`create server on: ${this.port}, ${this.webhookUrl}`);
+    this.server = http.createServer(
+      async (request: http.ServerRequest, response: http.ServerResponse) => {
+        const body: Array<string | Buffer> = [];
+        request
+          .on('data', chunk => {
+            body.push(chunk);
+          })
+          .on('end', async () => {
+            const requestData = Buffer.from(body).toString();
+            if (request.method !== 'POST' || request.url !== this.webhookUrl) {
+              response.statusCode = 400;
+              return response.end();
+            }
+            const requestBody = JSON.parse(requestData);
+            const responseBody = await this.handleRequest(requestBody);
+            response.statusCode = 200;
+            response.setHeader('Content-Type', 'application/json');
+            response.end(JSON.stringify(responseBody));
+          });
+      },
+    );
+    return this;
+  }
+
+  public start(): void {
+    if (this.isServerStarted) {
+      throw new Error(`Server is already started`);
+    }
+    this.server.listen(this.port, () => {
+      debug(`server is listening on ${this.port}, '${this.webhookUrl}'`);
+      this.isServerStarted = true;
+    });
+  }
+
+  public stop(): void {
+    if (this.isServerStarted) {
+      debug(`stopping webhook server`);
+      this.server.close();
+      this.isServerStarted = false;
+    }
+  }
+}

--- a/src/server/webhookServer.ts
+++ b/src/server/webhookServer.ts
@@ -3,13 +3,13 @@ import debug from '../debug';
 import { IApiRequest } from '../api/request';
 import { IApiResponse } from '../api/response';
 
-type handleAliceRequestType = (request: IApiRequest) => Promise<IApiResponse>;
+type HandleAliceRequestType = (request: IApiRequest) => Promise<IApiResponse>;
 
 export interface IWebhookServerConfig {
   port: number;
   webhookUrl: string;
   options: object;
-  handleRequest: handleAliceRequestType;
+  handleRequest: HandleAliceRequestType;
 }
 export interface IWebhookServer {
   start(): void;
@@ -21,7 +21,7 @@ export class WebhookServer {
   private port: number;
   private webhookUrl: string;
   private _isStarted: boolean;
-  private _handleAliceRequest: handleAliceRequestType;
+  private _handleAliceRequest: HandleAliceRequestType;
 
   constructor(config: IWebhookServerConfig) {
     this.port = config.port;

--- a/src/server/webhookServer.ts
+++ b/src/server/webhookServer.ts
@@ -1,15 +1,15 @@
 import * as http from 'http';
-import _debug from 'debug';
-import { LIBRARY_NAME } from '../constants';
-import { IAlice } from '../alice';
+import debug from '../debug';
+import { IApiRequest } from '../api/request';
+import { IApiResponse } from '../api/response';
 
-const debug = _debug(LIBRARY_NAME);
+type handleAliceRequestType = (request: IApiRequest) => Promise<IApiResponse>;
 
 export interface IWebhookServerConfig {
   port: number;
   webhookUrl: string;
   options: object;
-  handleRequest: IAlice['handleRequest'];
+  handleRequest: handleAliceRequestType;
 }
 export interface IWebhookServer {
   start(): void;
@@ -20,55 +20,76 @@ export class WebhookServer {
   private server: http.Server;
   private port: number;
   private webhookUrl: string;
-  private isServerStarted: boolean;
-  private handleRequest: IAlice['handleRequest'];
+  private _isStarted: boolean;
+  private _handleAliceRequest: handleAliceRequestType;
 
   constructor(config: IWebhookServerConfig) {
     this.port = config.port;
     this.webhookUrl = config.webhookUrl;
-    this.handleRequest = config.handleRequest;
-    this.isServerStarted = false;
+    this._handleAliceRequest = config.handleRequest;
+    this._isStarted = false;
 
-    debug(`create server on: ${this.port}, ${this.webhookUrl}`);
-    this.server = http.createServer(
-      async (request: http.ServerRequest, response: http.ServerResponse) => {
-        const body: Array<string | Buffer> = [];
-        request
-          .on('data', chunk => {
-            body.push(chunk);
-          })
-          .on('end', async () => {
-            const requestData = Buffer.from(body).toString();
-            if (request.method !== 'POST' || request.url !== this.webhookUrl) {
-              response.statusCode = 400;
-              return response.end();
-            }
-            const requestBody = JSON.parse(requestData);
-            const responseBody = await this.handleRequest(requestBody);
-            response.statusCode = 200;
-            response.setHeader('Content-Type', 'application/json');
-            response.end(JSON.stringify(responseBody));
-          });
-      },
+    debug(`server is listening: ${this.port}, ${this.webhookUrl}`);
+    this.server = http.createServer((request, response) =>
+      this._handleRequest(request, response),
     );
-    return this;
+  }
+
+  private async _handleRequest(
+    request: http.IncomingMessage,
+    response: http.ServerResponse,
+  ): Promise<void> {
+    if (request.method !== 'POST' || request.url !== this.webhookUrl) {
+      response.statusCode = 400;
+      return response.end();
+    }
+
+    const requestBody = await WebhookServer._readRequest(request);
+    const responseBody = await this._handleAliceRequest(requestBody);
+    WebhookServer._sendResponse(response, responseBody);
+  }
+
+  private static _readRequest(
+    request: http.IncomingMessage,
+  ): Promise<IApiRequest> {
+    return new Promise((resolve, reject) => {
+      const body: Array<string | Buffer> = [];
+      request
+        .on('data', chunk => {
+          body.push(chunk);
+        })
+        .on('end', async () => {
+          const requestData = Buffer.from(body).toString();
+          resolve(JSON.parse(requestData));
+        })
+        .on('error', reject);
+    });
+  }
+  private static async _sendResponse(
+    response: http.ServerResponse,
+    responseBody: IApiResponse,
+  ) {
+    response.statusCode = 200;
+    response.setHeader('Content-Type', 'application/json');
+    response.end(JSON.stringify(responseBody));
   }
 
   public start(): void {
-    if (this.isServerStarted) {
+    if (this._isStarted) {
       throw new Error(`Server is already started`);
     }
     this.server.listen(this.port, () => {
       debug(`server is listening on ${this.port}, '${this.webhookUrl}'`);
-      this.isServerStarted = true;
+      this._isStarted = true;
     });
   }
 
   public stop(): void {
-    if (this.isServerStarted) {
-      debug(`stopping webhook server`);
-      this.server.close();
-      this.isServerStarted = false;
+    if (!this._isStarted) {
+      return;
     }
+    debug(`stopping webhook server`);
+    this.server.close();
+    this._isStarted = false;
   }
 }

--- a/src/stage/scene.ts
+++ b/src/stage/scene.ts
@@ -43,7 +43,7 @@ export class Scene<TContext extends IStageContext = IStageContext>
 
   private async run(context: TContext): Promise<CommandCallbackResult> {
     const command = await this._commands.getMostRelevant(context);
-    if (!command) {
+    if (command) {
       return command.run(context);
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
         "paths": {
             "*": ["node_modules/*"]
         },
-        "types": ["node", "jest"],
+        "types": ["node", "jest", "debug"],
         "typeRoots": [
             "node_modules/@types"
         ]

--- a/tslint.json
+++ b/tslint.json
@@ -14,6 +14,7 @@
 		"arrow-parens": false,
 		"object-literal-shorthand": false,
 		"only-arrow-functions": false,
+		"member-ordering": false
 	},
 	"rulesDirectory": []
 }


### PR DESCRIPTION
Design questions on implementation:



- is it okay to return server instance in `listen()` method?

example:
```javascript
const server = alice.listen(8080, '/', () => console.log('listening on 8080'))
```

this enables to use `server.stopListening` directly from developer code

- is `listen()`'s argument's order okay? I think `port` should be the first, `webhookUrl` as the second & optional `callback` is the third.

```javascript
// 1.5.2
alice.listen('/', 8080, () => null)
// 2.0
alice.listen(8080, '/', () => null)
```

I did it because most of the developers don't use `webhookUrl` (they're actually using default `'/'`)